### PR TITLE
Deploy query lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ This stored data structure means we have a slower transformation and load step, 
 ./scripts/query_api.sh
 ```
 
+7. Remove all resources used in this demo by deleting the Cloudformation stack
+
+```bash
+aws cloudformation delete-stack --stack-name event-processing-demo
+```
+
 ## TODO
 
 - Improve error handling and logging

--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ This stored data structure means we have a slower transformation and load step, 
 
 5. Look at the SQS, Lambda and DynamoDB monitoring in AWS to see the event travel through the system
 
+6. Run the query script to call the query Lambda via API Gateway
+
+```bash
+./scripts/query_api.sh
+```
+
 ## TODO
 
-- Query Lambda
-- Cloudformation & scripts to deploy
-- Scripts to add events to the SQS queue & run a query
 - Improve error handling and logging

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -84,9 +84,82 @@ Resources:
           - logs:CreateLogGroup
           Resource: "*"
 
+  QueryLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      Architectures: ["arm64"]
+      Handler: bootstrap
+      Runtime: provided.al2
+      Timeout: 5
+      CodeUri: ../query/target/lambda/query/
+      Role: !GetAtt QueryRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref DataStoreTableName
+    DependsOn:
+      - QueryPolicy
+
+  QueryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+
+  QueryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Roles:
+        - !Ref QueryRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - dynamodb:Query
+          - dynamodb:GetItem
+          Resource: 
+          - !GetAtt DataStore.Arn
+          - !Sub 
+            - '${Arn}/*'
+            - Arn: !GetAtt DataStore.Arn
+            
+
+        - Effect: Allow
+          Action:
+          - logs:PutLogEvents
+          - logs:CreateLogStream
+          - logs:CreateLogGroup
+          Resource: "*"
+  
+  QueryPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt QueryLambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+
+  ApiGateway:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: event-demo
+      ProtocolType: HTTP
+      Target: !GetAtt QueryLambda.Arn
+
 Outputs:
   EventHandlerFunction:
     Value: !Ref EventHandlerFunction
 
   QueueUrl:
     Value: !Ref Queue
+
+  ApiEndpoint:
+    Value: !GetAtt ApiGateway.ApiEndpoint

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 aws-config = "0.46.0"
 aws-sdk-dynamodb = "0.16.0"
 common = { path = "../common" }
-lambda_http = { version = "0.6.0", default-features = false, features = ["apigw_rest"] }
+lambda_http = { version = "0.6.0" }
 lambda_runtime = "0.6.0"
 serde = "1.0.140"
 serde_json = "1.0.82"

--- a/query/src/main.rs
+++ b/query/src/main.rs
@@ -35,7 +35,6 @@ async fn get_user_services(user_id: String) -> Result<UserRecord, Error> {
     let req = client
         .query()
         .table_name("user_services")
-        .index_name("user_id")
         .expression_attribute_values(":user_id", AttributeValue::S(user_id.to_owned()))
         .key_condition_expression("user_id = :user_id");
 

--- a/query/src/main.rs
+++ b/query/src/main.rs
@@ -36,8 +36,8 @@ async fn get_user_services(user_id: String) -> Result<UserRecord, Error> {
         .query()
         .table_name("user_services")
         .index_name("user_id")
-        .key_condition_expression("user_id = :user_id")
-        .expression_attribute_values("user_id", AttributeValue::S(user_id.to_owned()));
+        .expression_attribute_values(":user_id", AttributeValue::S(user_id.to_owned()))
+        .key_condition_expression("user_id = :user_id");
 
     let res = req.send().await.expect("Error querying DynamoDB");
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,5 +3,8 @@
 cd event-handler
 cargo lambda build --release --arm64
 
+cd ../query
+cargo lambda build --release --arm64
+
 cd ../infrastructure
 sam deploy

--- a/scripts/query_api.sh
+++ b/scripts/query_api.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+api_url=`aws cloudformation describe-stacks --stack-name event-processing-demo | jq -r '.Stacks[0].Outputs[0].OutputValue'`
+
+query_url="${api_url}?user_id=1234"
+
+curl $query_url

--- a/scripts/write_sample_event_to_queue.sh
+++ b/scripts/write_sample_event_to_queue.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-queue_url=`aws cloudformation describe-stacks --stack-name event-processing-demo | jq -r '.Stacks[0].Outputs[1].OutputValue'`
+queue_url=`aws cloudformation describe-stacks --stack-name event-processing-demo | jq -r '.Stacks[0].Outputs[2].OutputValue'`
 
 aws sqs send-message --queue-url \
   $queue_url \


### PR DESCRIPTION
Add Cloudformation resources, instructions and helper scripts to deploy the query Lambda behind API Gateway. 

With this PR the demo app is fully functional and the bulk of the work is done. You can put events onto the queue which are transformed and stored in DynamoDB, then query the API to see the stored events! 